### PR TITLE
feat(entities): 天気APIフェッチ関数とドメイン型を実装

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.90.21",

--- a/src/entities/weather/api/weather-api.test.ts
+++ b/src/entities/weather/api/weather-api.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { fetchDailyWeather, fetchHourlyWeather } from './weather-api'
+import { CITIES } from '../constants/cities'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch
+
+describe('weather-api', () => {
+  beforeEach(() => {
+    mockFetch.mockReset()
+  })
+
+  describe('fetchHourlyWeather', () => {
+    it('正しいURLとパラメータでfetchが呼ばれること', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          latitude: CITIES.tokyo.lat,
+          longitude: CITIES.tokyo.lon,
+          timezone: 'Asia/Tokyo',
+          hourly: {
+            time: ['2026-01-01T00:00'],
+            temperature_2m: [10],
+          },
+        }),
+      })
+
+      const res = await fetchHourlyWeather({
+        city: 'tokyo',
+        metrics: ['temperature_2m', 'apparent_temperature'],
+      })
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const requestedUrlString = mockFetch.mock.calls[0][0]
+      const requestedUrl = new URL(requestedUrlString)
+
+      expect(requestedUrl.origin + requestedUrl.pathname).toBe(
+        'https://api.open-meteo.com/v1/forecast',
+      )
+      expect(requestedUrl.searchParams.get('latitude')).toBe(
+        CITIES.tokyo.lat.toString(),
+      )
+      expect(requestedUrl.searchParams.get('longitude')).toBe(
+        CITIES.tokyo.lon.toString(),
+      )
+      expect(requestedUrl.searchParams.get('hourly')).toBe(
+        'temperature_2m,apparent_temperature',
+      )
+      expect(requestedUrl.searchParams.get('forecast_days')).toBe('2')
+      expect(requestedUrl.searchParams.get('temperature_unit')).toBe('celsius')
+
+      expect(res.timezone).toBe('Asia/Tokyo')
+      expect(res.hourly.temperature_2m).toEqual([10])
+    })
+
+    it('エラーを含むレスポンスの場合は例外をスローすること', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+      })
+
+      await expect(
+        fetchHourlyWeather({ city: 'tokyo', metrics: ['temperature_2m'] }),
+      ).rejects.toThrow('Failed to fetch hourly weather data')
+    })
+  })
+
+  describe('fetchDailyWeather', () => {
+    it('正しいURLとパラメータでfetchが呼ばれること', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          latitude: CITIES.osaka.lat,
+          longitude: CITIES.osaka.lon,
+          timezone: 'Asia/Tokyo',
+          daily: {
+            time: ['2026-01-01'],
+            temperature_2m_max: [15],
+            temperature_2m_min: [5],
+          },
+        }),
+      })
+
+      const res = await fetchDailyWeather({ city: 'osaka' })
+
+      expect(mockFetch).toHaveBeenCalledTimes(1)
+      const requestedUrlString = mockFetch.mock.calls[0][0]
+      const requestedUrl = new URL(requestedUrlString)
+
+      expect(requestedUrl.origin + requestedUrl.pathname).toBe(
+        'https://api.open-meteo.com/v1/forecast',
+      )
+      expect(requestedUrl.searchParams.get('latitude')).toBe(
+        CITIES.osaka.lat.toString(),
+      )
+      expect(requestedUrl.searchParams.get('longitude')).toBe(
+        CITIES.osaka.lon.toString(),
+      )
+      expect(requestedUrl.searchParams.get('daily')).toBe(
+        'temperature_2m_max,temperature_2m_min',
+      )
+      expect(requestedUrl.searchParams.get('forecast_days')).toBe('7')
+
+      expect(res.timezone).toBe('Asia/Tokyo')
+      expect(res.daily.temperature_2m_max).toEqual([15])
+    })
+
+    it('エラーを含むレスポンスの場合は例外をスローすること', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+      })
+
+      await expect(fetchDailyWeather({ city: 'osaka' })).rejects.toThrow(
+        'Failed to fetch daily weather data',
+      )
+    })
+  })
+})

--- a/src/entities/weather/api/weather-api.ts
+++ b/src/entities/weather/api/weather-api.ts
@@ -1,0 +1,60 @@
+import { CITIES } from '../constants/cities'
+import {
+  City,
+  DailyResponse,
+  HourlyMetric,
+  HourlyResponse,
+} from '../model/types'
+
+const OPEN_METEO_BASE_URL = 'https://api.open-meteo.com/v1/forecast'
+
+export type FetchHourlyParams = {
+  city: City
+  metrics: HourlyMetric[]
+}
+
+export type FetchDailyParams = {
+  city: City
+}
+
+export const fetchHourlyWeather = async ({
+  city,
+  metrics,
+}: FetchHourlyParams): Promise<HourlyResponse> => {
+  const { lat, lon } = CITIES[city]
+  const metricsParam = metrics.join(',')
+
+  const url = new URL(OPEN_METEO_BASE_URL)
+  url.searchParams.append('latitude', lat.toString())
+  url.searchParams.append('longitude', lon.toString())
+  url.searchParams.append('hourly', metricsParam)
+  url.searchParams.append('forecast_days', '2')
+  url.searchParams.append('timezone', 'auto')
+  url.searchParams.append('temperature_unit', 'celsius')
+
+  const res = await fetch(url.toString())
+  if (!res.ok) {
+    throw new Error('Failed to fetch hourly weather data')
+  }
+  return res.json()
+}
+
+export const fetchDailyWeather = async ({
+  city,
+}: FetchDailyParams): Promise<DailyResponse> => {
+  const { lat, lon } = CITIES[city]
+
+  const url = new URL(OPEN_METEO_BASE_URL)
+  url.searchParams.append('latitude', lat.toString())
+  url.searchParams.append('longitude', lon.toString())
+  url.searchParams.append('daily', 'temperature_2m_max,temperature_2m_min')
+  url.searchParams.append('forecast_days', '7')
+  url.searchParams.append('timezone', 'auto')
+  url.searchParams.append('temperature_unit', 'celsius')
+
+  const res = await fetch(url.toString())
+  if (!res.ok) {
+    throw new Error('Failed to fetch daily weather data')
+  }
+  return res.json()
+}

--- a/src/entities/weather/constants/cities.ts
+++ b/src/entities/weather/constants/cities.ts
@@ -1,0 +1,9 @@
+import { City } from '../model/types'
+
+export const CITIES: Record<City, { label: string; lat: number; lon: number }> = {
+  tokyo: { label: '東京', lat: 35.6895, lon: 139.6917 },
+  osaka: { label: '大阪', lat: 34.6937, lon: 135.5023 },
+  sapporo: { label: '札幌', lat: 43.0618, lon: 141.3545 },
+  fukuoka: { label: '福岡', lat: 33.5902, lon: 130.4017 },
+  naha: { label: '那覇', lat: 26.2124, lon: 127.6809 },
+}

--- a/src/entities/weather/constants/metrics.ts
+++ b/src/entities/weather/constants/metrics.ts
@@ -1,0 +1,13 @@
+import { Metric } from '../model/types'
+
+export const METRICS: Record<
+  Metric,
+  { label: string; defaultUnit?: string; isDailyOnly?: boolean }
+> = {
+  temperature_2m: { label: '気温' },
+  apparent_temperature: { label: '体感温度' },
+  precipitation: { label: '降水量', defaultUnit: 'mm' },
+  windspeed_10m: { label: '風速' },
+  temperature_2m_max: { label: '最高気温', isDailyOnly: true },
+  temperature_2m_min: { label: '最低気温', isDailyOnly: true },
+}

--- a/src/entities/weather/model/types.ts
+++ b/src/entities/weather/model/types.ts
@@ -1,0 +1,49 @@
+export type BaseResponse = {
+  latitude: number
+  longitude: number
+  timezone: string
+}
+
+export type HourlyResponse = BaseResponse & {
+  hourly: {
+    time: string[]
+    temperature_2m: number[]
+    apparent_temperature: number[]
+    precipitation: number[]
+    windspeed_10m: number[]
+  }
+}
+
+export type DailyResponse = BaseResponse & {
+  daily: {
+    time: string[]
+    temperature_2m_max: number[]
+    temperature_2m_min: number[]
+  }
+}
+
+export type City = 'tokyo' | 'osaka' | 'sapporo' | 'fukuoka' | 'naha'
+export type Period = '48h' | '7d'
+
+export type HourlyMetric =
+  | 'temperature_2m'
+  | 'apparent_temperature'
+  | 'precipitation'
+  | 'windspeed_10m'
+export type DailyMetric = 'temperature_2m_max' | 'temperature_2m_min'
+export type Metric = HourlyMetric | DailyMetric
+
+export type UnitState = {
+  temp: 'C' | 'F'
+  wind: 'ms' | 'kmh'
+}
+
+export type ChartDataPoint = {
+  time: string
+  temperature_2m?: number
+  apparent_temperature?: number
+  precipitation?: number
+  windspeed_10m?: number
+  temperature_2m_max?: number
+  temperature_2m_min?: number
+}


### PR DESCRIPTION
## 概要

Open-Meteoの/v1/forecastエンドポイントに対してhourly/dailyを切り替えてフェッチする関数を実装した。また、前提となるドメイン型と各種定数を定義した。

## 対応内容

- [x] fetchHourlyWeather関数の実装
- [x] fetchDailyWeather関数の実装
- [x] HourlyResponse・DailyResponse等各種ドメイン型の定義
- [x] 都市・指標の定数定義
- [x] API通信部分のユニットテスト作成

## 変更の背景・目的

都市・指標・期間の選択に応じて適切なAPIパラメータを組み立て、型安全に天気データを取得する必要があった。このタスクは他のUI機能に依拠しないため先行して実装を行った。

## 動作確認

- [x] `npm run test` により weather-api のテストがパスすること
- [x] 型エラー等の Lint(`npm run lint`)・Build(`npm run build`) チェックが通ること

## 関連Issue

close #2
