### PR TITLE
feat(pages): 状態管理とアプリケーション統合

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@storybook/addon-vitest": "^10.3.0",
         "@storybook/react-vite": "^10.3.0",
         "@tailwindcss/vite": "^4.2.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^25.5.0",
@@ -2247,6 +2248,43 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -2319,6 +2357,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -3762,6 +3807,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -5209,6 +5264,16 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -5684,6 +5749,51 @@
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@storybook/addon-vitest": "^10.3.0",
     "@storybook/react-vite": "^10.3.0",
     "@tailwindcss/vite": "^4.2.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^25.5.0",

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,9 +1,12 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { WeatherPage } from '@/pages/weather'
+
+const queryClient = new QueryClient()
+
 export function App() {
-  return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center">
-      <h1 className="text-3xl font-bold text-slate-800">
-        Tamable Weather Dashboard
-      </h1>
-    </div>
-  )
+    return (
+        <QueryClientProvider client={queryClient}>
+            <WeatherPage />
+        </QueryClientProvider>
+    )
 }

--- a/src/entities/weather/api/weather-api.test.ts
+++ b/src/entities/weather/api/weather-api.test.ts
@@ -43,9 +43,10 @@ describe('weather-api', () => {
       expect(requestedUrl.searchParams.get('longitude')).toBe(
         CITIES.tokyo.lon.toString(),
       )
-      expect(requestedUrl.searchParams.get('hourly')).toBe(
-        'temperature_2m,apparent_temperature',
-      )
+      expect(requestedUrl.searchParams.getAll('hourly')).toEqual([
+        'temperature_2m',
+        'apparent_temperature',
+      ])
       expect(requestedUrl.searchParams.get('forecast_days')).toBe('2')
       expect(requestedUrl.searchParams.get('temperature_unit')).toBe('celsius')
 
@@ -80,7 +81,10 @@ describe('weather-api', () => {
         }),
       })
 
-      const res = await fetchDailyWeather({ city: 'osaka' })
+      const res = await fetchDailyWeather({
+        city: 'osaka',
+        metrics: ['temperature_2m_max', 'temperature_2m_min'],
+      })
 
       expect(mockFetch).toHaveBeenCalledTimes(1)
       const requestedUrlString = mockFetch.mock.calls[0][0]
@@ -95,9 +99,10 @@ describe('weather-api', () => {
       expect(requestedUrl.searchParams.get('longitude')).toBe(
         CITIES.osaka.lon.toString(),
       )
-      expect(requestedUrl.searchParams.get('daily')).toBe(
-        'temperature_2m_max,temperature_2m_min',
-      )
+      expect(requestedUrl.searchParams.getAll('daily')).toEqual([
+        'temperature_2m_max',
+        'temperature_2m_min',
+      ])
       expect(requestedUrl.searchParams.get('forecast_days')).toBe('7')
 
       expect(res.timezone).toBe('Asia/Tokyo')
@@ -109,9 +114,9 @@ describe('weather-api', () => {
         ok: false,
       })
 
-      await expect(fetchDailyWeather({ city: 'osaka' })).rejects.toThrow(
-        'Failed to fetch daily weather data',
-      )
+      await expect(
+        fetchDailyWeather({ city: 'osaka', metrics: ['temperature_2m_max'] }),
+      ).rejects.toThrow('Failed to fetch daily weather data')
     })
   })
 })

--- a/src/entities/weather/api/weather-api.ts
+++ b/src/entities/weather/api/weather-api.ts
@@ -3,6 +3,7 @@ import {
   City,
   DailyResponse,
   HourlyMetric,
+  DailyMetric,
   HourlyResponse,
 } from '../model/types'
 
@@ -15,6 +16,7 @@ export type FetchHourlyParams = {
 
 export type FetchDailyParams = {
   city: City
+  metrics: DailyMetric[]
 }
 
 export const fetchHourlyWeather = async ({
@@ -22,12 +24,11 @@ export const fetchHourlyWeather = async ({
   metrics,
 }: FetchHourlyParams): Promise<HourlyResponse> => {
   const { lat, lon } = CITIES[city]
-  const metricsParam = metrics.join(',')
 
   const url = new URL(OPEN_METEO_BASE_URL)
   url.searchParams.append('latitude', lat.toString())
   url.searchParams.append('longitude', lon.toString())
-  url.searchParams.append('hourly', metricsParam)
+  metrics.forEach((m) => url.searchParams.append('hourly', m))
   url.searchParams.append('forecast_days', '2')
   url.searchParams.append('timezone', 'auto')
   url.searchParams.append('temperature_unit', 'celsius')
@@ -41,13 +42,14 @@ export const fetchHourlyWeather = async ({
 
 export const fetchDailyWeather = async ({
   city,
+  metrics,
 }: FetchDailyParams): Promise<DailyResponse> => {
   const { lat, lon } = CITIES[city]
 
   const url = new URL(OPEN_METEO_BASE_URL)
   url.searchParams.append('latitude', lat.toString())
   url.searchParams.append('longitude', lon.toString())
-  url.searchParams.append('daily', 'temperature_2m_max,temperature_2m_min')
+  metrics.forEach((m) => url.searchParams.append('daily', m))
   url.searchParams.append('forecast_days', '7')
   url.searchParams.append('timezone', 'auto')
   url.searchParams.append('temperature_unit', 'celsius')

--- a/src/entities/weather/index.ts
+++ b/src/entities/weather/index.ts
@@ -29,5 +29,12 @@ export { TEMP_UNIT, WIND_UNIT } from './constants/units'
 export { convertTemp, convertWindSpeed } from './lib/unit-converter'
 export { formatHourlyData, formatDailyData } from './lib/weather-formatter'
 
+// model/weather-store
+export { useWeatherStore } from './model/weather-store'
+export type { WeatherStore } from './model/weather-store'
+
+// model/use-weather-query
+export { useWeatherQuery } from './model/use-weather-query'
+
 // ui
 export { WeatherChart } from './ui/weather-chart'

--- a/src/entities/weather/lib/weather-formatter.test.ts
+++ b/src/entities/weather/lib/weather-formatter.test.ts
@@ -61,6 +61,27 @@ describe('weather-formatter', () => {
         windspeed_10m: 7.2 // 2 * 3.6
       })
     })
+
+    it('一部の指標が欠落していてもエラーにならずundefinedを返すこと', () => {
+      const incompleteData: HourlyResponse = {
+        ...mockHourlyData,
+        hourly: {
+          time: ['2024-01-01T00:00'],
+          temperature_2m: [10],
+          // 他の指標が欠落
+        } as any
+      }
+      const unitState: UnitState = { temp: 'C', wind: 'ms' }
+      const result = formatHourlyData(incompleteData, unitState)
+
+      expect(result[0]).toEqual({
+        time: '2024-01-01T00:00',
+        temperature_2m: 10,
+        apparent_temperature: undefined,
+        precipitation: undefined,
+        windspeed_10m: undefined
+      })
+    })
   })
 
   describe('formatDailyData', () => {
@@ -84,6 +105,25 @@ describe('weather-formatter', () => {
         time: '2024-01-01',
         temperature_2m_max: 59, // 15 * 1.8 + 32
         temperature_2m_min: 41  // 5 * 1.8 + 32
+      })
+    })
+
+    it('一部の指標が欠落していてもエラーにならずundefinedを返すこと', () => {
+      const incompleteData: DailyResponse = {
+        ...mockDailyData,
+        daily: {
+          time: ['2024-01-01'],
+          temperature_2m_max: [15],
+          // temperature_2m_min が欠落
+        } as any
+      }
+      const unitState: UnitState = { temp: 'C', wind: 'ms' }
+      const result = formatDailyData(incompleteData, unitState)
+
+      expect(result[0]).toEqual({
+        time: '2024-01-01',
+        temperature_2m_max: 15,
+        temperature_2m_min: undefined
       })
     })
   })

--- a/src/entities/weather/lib/weather-formatter.ts
+++ b/src/entities/weather/lib/weather-formatter.ts
@@ -12,10 +12,10 @@ export const formatHourlyData = (data: HourlyResponse, unitState: UnitState): Ch
 
   return time.map((t, index) => ({
     time: t,
-    temperature_2m: convertTemp(temperature_2m[index], isFahrenheit),
-    apparent_temperature: convertTemp(apparent_temperature[index], isFahrenheit),
-    precipitation: precipitation[index],
-    windspeed_10m: convertWindSpeed(windspeed_10m[index], isKmh),
+    temperature_2m: temperature_2m ? convertTemp(temperature_2m[index], isFahrenheit) : undefined,
+    apparent_temperature: apparent_temperature ? convertTemp(apparent_temperature[index], isFahrenheit) : undefined,
+    precipitation: precipitation ? precipitation[index] : undefined,
+    windspeed_10m: windspeed_10m ? convertWindSpeed(windspeed_10m[index], isKmh) : undefined,
   }))
 }
 
@@ -29,7 +29,7 @@ export const formatDailyData = (data: DailyResponse, unitState: UnitState): Char
 
   return time.map((t, index) => ({
     time: t,
-    temperature_2m_max: convertTemp(temperature_2m_max[index], isFahrenheit),
-    temperature_2m_min: convertTemp(temperature_2m_min[index], isFahrenheit),
+    temperature_2m_max: temperature_2m_max ? convertTemp(temperature_2m_max[index], isFahrenheit) : undefined,
+    temperature_2m_min: temperature_2m_min ? convertTemp(temperature_2m_min[index], isFahrenheit) : undefined,
   }))
 }

--- a/src/entities/weather/model/use-weather-query.test.ts
+++ b/src/entities/weather/model/use-weather-query.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { createElement, type ReactNode } from 'react'
+import { useWeatherQuery } from './use-weather-query'
+import * as weatherApi from '../api/weather-api'
+import type { HourlyResponse, DailyResponse } from './types'
+
+vi.mock('../api/weather-api')
+
+const mockFetchHourly = vi.mocked(weatherApi.fetchHourlyWeather)
+const mockFetchDaily = vi.mocked(weatherApi.fetchDailyWeather)
+
+const createWrapper = () => {
+    const queryClient = new QueryClient({
+        defaultOptions: {
+            queries: { retry: false },
+        },
+    })
+    return ({ children }: { children: ReactNode }) =>
+        createElement(
+            QueryClientProvider,
+            { client: queryClient },
+            children,
+        )
+}
+
+const hourlyResponse: HourlyResponse = {
+    latitude: 35.6762,
+    longitude: 139.6503,
+    timezone: 'Asia/Tokyo',
+    hourly: {
+        time: ['2026-01-01T00:00', '2026-01-01T01:00'],
+        temperature_2m: [10, 12],
+        apparent_temperature: [8, 10],
+        precipitation: [0, 0.5],
+        windspeed_10m: [3, 5],
+    },
+}
+
+const dailyResponse: DailyResponse = {
+    latitude: 35.6762,
+    longitude: 139.6503,
+    timezone: 'Asia/Tokyo',
+    daily: {
+        time: ['2026-01-01', '2026-01-02'],
+        temperature_2m_max: [15, 18],
+        temperature_2m_min: [5, 8],
+    },
+}
+
+describe('useWeatherQuery', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('48h期間の場合、fetchHourlyWeatherが呼ばれること', async () => {
+        mockFetchHourly.mockResolvedValueOnce(hourlyResponse)
+
+        const { result } = renderHook(
+            () =>
+                useWeatherQuery('tokyo', '48h', ['temperature_2m'], {
+                    temp: 'C',
+                    wind: 'ms',
+                }),
+            { wrapper: createWrapper() },
+        )
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        expect(mockFetchHourly).toHaveBeenCalledWith({
+            city: 'tokyo',
+            metrics: ['temperature_2m'],
+        })
+        expect(mockFetchDaily).not.toHaveBeenCalled()
+        expect(result.current.data).toHaveLength(2)
+    })
+
+    it('7d期間の場合、fetchDailyWeatherが呼ばれること', async () => {
+        mockFetchDaily.mockResolvedValueOnce(dailyResponse)
+
+        const { result } = renderHook(
+            () =>
+                useWeatherQuery(
+                    'osaka',
+                    '7d',
+                    ['temperature_2m_max'],
+                    { temp: 'C', wind: 'ms' },
+                ),
+            { wrapper: createWrapper() },
+        )
+
+        await waitFor(() => expect(result.current.isSuccess).toBe(true))
+
+        expect(mockFetchDaily).toHaveBeenCalledWith({
+            city: 'osaka',
+            metrics: ['temperature_2m_max'],
+        })
+        expect(mockFetchHourly).not.toHaveBeenCalled()
+        expect(result.current.data).toHaveLength(2)
+    })
+
+    it('metricsが空の場合、クエリが無効化されること', () => {
+        const { result } = renderHook(
+            () =>
+                useWeatherQuery('tokyo', '48h', [], {
+                    temp: 'C',
+                    wind: 'ms',
+                }),
+            { wrapper: createWrapper() },
+        )
+
+        expect(result.current.fetchStatus).toBe('idle')
+        expect(mockFetchHourly).not.toHaveBeenCalled()
+        expect(mockFetchDaily).not.toHaveBeenCalled()
+    })
+
+    it('APIエラー時にisErrorがtrueになること', async () => {
+        mockFetchHourly.mockRejectedValueOnce(new Error('Network error'))
+
+        const { result } = renderHook(
+            () =>
+                useWeatherQuery('tokyo', '48h', ['temperature_2m'], {
+                    temp: 'C',
+                    wind: 'ms',
+                }),
+            { wrapper: createWrapper() },
+        )
+
+        await waitFor(() => expect(result.current.isError).toBe(true))
+    })
+})

--- a/src/entities/weather/model/use-weather-query.ts
+++ b/src/entities/weather/model/use-weather-query.ts
@@ -1,0 +1,60 @@
+import { useQuery } from '@tanstack/react-query'
+import {
+    City,
+    Period,
+    Metric,
+    HourlyMetric,
+    DailyMetric,
+    UnitState,
+    ChartDataPoint,
+    HourlyResponse,
+    DailyResponse,
+} from './types'
+import { fetchHourlyWeather, fetchDailyWeather } from '../api/weather-api'
+import { formatHourlyData, formatDailyData } from '../lib/weather-formatter'
+
+const HOURLY_METRICS: HourlyMetric[] = [
+    'temperature_2m',
+    'apparent_temperature',
+    'precipitation',
+    'windspeed_10m',
+]
+
+const DAILY_METRICS: DailyMetric[] = ['temperature_2m_max', 'temperature_2m_min']
+
+export const useWeatherQuery = (
+    city: City,
+    period: Period,
+    metrics: Metric[],
+    unitState: UnitState,
+) => {
+    return useQuery<ChartDataPoint[]>({
+        queryKey: ['weather', city, period, [...metrics].sort(), unitState],
+        queryFn: async () => {
+            if (period === '48h') {
+                const hourlyMetrics = metrics.filter(
+                    (m): m is HourlyMetric =>
+                        HOURLY_METRICS.includes(m as HourlyMetric),
+                )
+                const response: HourlyResponse = await fetchHourlyWeather({
+                    city,
+                    metrics: hourlyMetrics,
+                })
+                return formatHourlyData(response, unitState)
+            } else {
+                const dailyMetrics = metrics.filter(
+                    (m): m is DailyMetric =>
+                        DAILY_METRICS.includes(m as DailyMetric),
+                )
+                const response: DailyResponse = await fetchDailyWeather({
+                    city,
+                    metrics: dailyMetrics,
+                })
+                return formatDailyData(response, unitState)
+            }
+        },
+        staleTime: 5 * 60 * 1000,
+        gcTime: 10 * 60 * 1000,
+        enabled: metrics.length > 0,
+    })
+}

--- a/src/entities/weather/model/weather-store.test.ts
+++ b/src/entities/weather/model/weather-store.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { useWeatherStore } from './weather-store'
+
+describe('weather-store', () => {
+    beforeEach(() => {
+        // ストアを初期状態にリセット
+        useWeatherStore.setState({
+            city: 'tokyo',
+            period: '48h',
+            metrics: ['temperature_2m'],
+            unitState: { temp: 'C', wind: 'ms' },
+        })
+        localStorage.clear()
+    })
+
+    describe('初期状態', () => {
+        it('デフォルト値が正しくセットされていること', () => {
+            const state = useWeatherStore.getState()
+            expect(state.city).toBe('tokyo')
+            expect(state.period).toBe('48h')
+            expect(state.metrics).toEqual(['temperature_2m'])
+            expect(state.unitState).toEqual({ temp: 'C', wind: 'ms' })
+        })
+    })
+
+    describe('setCity', () => {
+        it('都市を変更できること', () => {
+            useWeatherStore.getState().setCity('osaka')
+            expect(useWeatherStore.getState().city).toBe('osaka')
+        })
+
+        it('全ての都市に変更できること', () => {
+            const cities = [
+                'tokyo',
+                'osaka',
+                'sapporo',
+                'fukuoka',
+                'naha',
+            ] as const
+            for (const city of cities) {
+                useWeatherStore.getState().setCity(city)
+                expect(useWeatherStore.getState().city).toBe(city)
+            }
+        })
+    })
+
+    describe('setPeriod', () => {
+        it('48hから7dに切り替えた場合、hourly指標が除外されdaily指標がセットされること', () => {
+            useWeatherStore.setState({
+                metrics: ['temperature_2m', 'precipitation'],
+            })
+            useWeatherStore.getState().setPeriod('7d')
+
+            const state = useWeatherStore.getState()
+            expect(state.period).toBe('7d')
+            // hourly指標は全て除外されるため、デフォルトのdaily指標がセットされる
+            expect(state.metrics).toEqual(['temperature_2m_max'])
+        })
+
+        it('7dから48hに切り替えた場合、daily指標が除外されhourly指標がセットされること', () => {
+            useWeatherStore.setState({
+                period: '7d',
+                metrics: ['temperature_2m_max', 'temperature_2m_min'],
+            })
+            useWeatherStore.getState().setPeriod('48h')
+
+            const state = useWeatherStore.getState()
+            expect(state.period).toBe('48h')
+            // daily指標は全て除外されるため、デフォルトのhourly指標がセットされる
+            expect(state.metrics).toEqual(['temperature_2m'])
+        })
+
+        it('同じ期間に切り替えても指標は保持されること', () => {
+            useWeatherStore.setState({
+                metrics: ['temperature_2m', 'precipitation'],
+            })
+            useWeatherStore.getState().setPeriod('48h')
+
+            expect(useWeatherStore.getState().metrics).toEqual([
+                'temperature_2m',
+                'precipitation',
+            ])
+        })
+    })
+
+    describe('setMetrics', () => {
+        it('指標を変更できること', () => {
+            useWeatherStore
+                .getState()
+                .setMetrics(['temperature_2m', 'windspeed_10m'])
+            expect(useWeatherStore.getState().metrics).toEqual([
+                'temperature_2m',
+                'windspeed_10m',
+            ])
+        })
+
+        it('空配列をセットできること', () => {
+            useWeatherStore.getState().setMetrics([])
+            expect(useWeatherStore.getState().metrics).toEqual([])
+        })
+    })
+
+    describe('setTempUnit', () => {
+        it('温度単位をFに変更できること', () => {
+            useWeatherStore.getState().setTempUnit('F')
+            expect(useWeatherStore.getState().unitState.temp).toBe('F')
+            // 風速単位は変わらないこと
+            expect(useWeatherStore.getState().unitState.wind).toBe('ms')
+        })
+
+        it('温度単位をCに戻せること', () => {
+            useWeatherStore.getState().setTempUnit('F')
+            useWeatherStore.getState().setTempUnit('C')
+            expect(useWeatherStore.getState().unitState.temp).toBe('C')
+        })
+    })
+
+    describe('setWindUnit', () => {
+        it('風速単位をkmhに変更できること', () => {
+            useWeatherStore.getState().setWindUnit('kmh')
+            expect(useWeatherStore.getState().unitState.wind).toBe('kmh')
+            // 温度単位は変わらないこと
+            expect(useWeatherStore.getState().unitState.temp).toBe('C')
+        })
+
+        it('風速単位をmsに戻せること', () => {
+            useWeatherStore.getState().setWindUnit('kmh')
+            useWeatherStore.getState().setWindUnit('ms')
+            expect(useWeatherStore.getState().unitState.wind).toBe('ms')
+        })
+    })
+
+    describe('localStorage永続化', () => {
+        it('状態がlocalStorageに保存されること', () => {
+            useWeatherStore.getState().setCity('fukuoka')
+            useWeatherStore.getState().setTempUnit('F')
+
+            const stored = localStorage.getItem('weather-store')
+            expect(stored).not.toBeNull()
+
+            const parsed = JSON.parse(stored!)
+            expect(parsed.state.city).toBe('fukuoka')
+            expect(parsed.state.unitState.temp).toBe('F')
+        })
+    })
+})

--- a/src/entities/weather/model/weather-store.ts
+++ b/src/entities/weather/model/weather-store.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+import { City, Period, Metric, UnitState } from './types'
+
+type WeatherState = {
+    city: City
+    period: Period
+    metrics: Metric[]
+    unitState: UnitState
+}
+
+type WeatherActions = {
+    setCity: (city: City) => void
+    setPeriod: (period: Period) => void
+    setMetrics: (metrics: Metric[]) => void
+    setTempUnit: (unit: UnitState['temp']) => void
+    setWindUnit: (unit: UnitState['wind']) => void
+}
+
+export type WeatherStore = WeatherState & WeatherActions
+
+const DEFAULT_STATE: WeatherState = {
+    city: 'tokyo',
+    period: '48h',
+    metrics: ['temperature_2m'],
+    unitState: { temp: 'C', wind: 'ms' },
+}
+
+export const useWeatherStore = create<WeatherStore>()(
+    persist(
+        (set) => ({
+            ...DEFAULT_STATE,
+            setCity: (city) => set({ city }),
+            setPeriod: (period) =>
+                set((state) => {
+                    // 期間切り替え時に、新しい期間で有効でない指標を除外する
+                    const hourlyMetrics: Metric[] = [
+                        'temperature_2m',
+                        'apparent_temperature',
+                        'precipitation',
+                        'windspeed_10m',
+                    ]
+                    const dailyMetrics: Metric[] = [
+                        'temperature_2m_max',
+                        'temperature_2m_min',
+                    ]
+                    const validMetrics =
+                        period === '48h' ? hourlyMetrics : dailyMetrics
+                    const filteredMetrics = state.metrics.filter((m) =>
+                        validMetrics.includes(m),
+                    )
+                    return {
+                        period,
+                        metrics:
+                            filteredMetrics.length > 0
+                                ? filteredMetrics
+                                : period === '48h'
+                                  ? ['temperature_2m']
+                                  : ['temperature_2m_max'],
+                    }
+                }),
+            setMetrics: (metrics) => set({ metrics }),
+            setTempUnit: (unit) =>
+                set((state) => ({
+                    unitState: { ...state.unitState, temp: unit },
+                })),
+            setWindUnit: (unit) =>
+                set((state) => ({
+                    unitState: { ...state.unitState, wind: unit },
+                })),
+        }),
+        {
+            name: 'weather-store',
+        },
+    ),
+)

--- a/src/pages/weather/index.ts
+++ b/src/pages/weather/index.ts
@@ -1,0 +1,1 @@
+export { WeatherPage } from './ui/page'

--- a/src/pages/weather/ui/page.tsx
+++ b/src/pages/weather/ui/page.tsx
@@ -1,0 +1,61 @@
+import { useWeatherStore, useWeatherQuery } from '@/entities/weather'
+import { ControlPanel } from '@/widgets/control-panel'
+import { WeatherChart } from '@/widgets/weather-chart'
+
+export function WeatherPage() {
+    const {
+        city,
+        period,
+        metrics,
+        unitState,
+        setCity,
+        setPeriod,
+        setMetrics,
+        setTempUnit,
+        setWindUnit,
+    } = useWeatherStore()
+
+    const { data, isLoading, isError, refetch } = useWeatherQuery(
+        city,
+        period,
+        metrics,
+        unitState,
+    )
+
+    return (
+        <div className="min-h-screen bg-slate-50">
+            <header className="bg-white border-b border-slate-200 shadow-sm">
+                <div className="max-w-5xl mx-auto px-4 py-4">
+                    <h1 className="text-2xl font-bold text-slate-800">
+                        天気ダッシュボード
+                    </h1>
+                </div>
+            </header>
+
+            <main className="max-w-5xl mx-auto px-4 py-6 flex flex-col gap-6">
+                <ControlPanel
+                    city={city}
+                    onCityChange={setCity}
+                    period={period}
+                    onPeriodChange={setPeriod}
+                    metrics={metrics}
+                    onMetricsChange={setMetrics}
+                    tempUnit={unitState.temp}
+                    onTempUnitChange={setTempUnit}
+                    windUnit={unitState.wind}
+                    onWindUnitChange={setWindUnit}
+                />
+
+                <WeatherChart
+                    isLoading={isLoading}
+                    isError={isError}
+                    onRetry={() => refetch()}
+                    data={data ?? []}
+                    metrics={metrics}
+                    period={period}
+                    unitState={unitState}
+                />
+            </main>
+        </div>
+    )
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -20,25 +20,37 @@ export default defineConfig({
     include: ['react-is']
   },
   test: {
-    projects: [{
-      extends: true,
-      plugins: [
-      // The plugin will run tests for the stories defined in your Storybook config
-      // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
-      storybookTest({
-        configDir: path.join(dirname, '.storybook')
-      })],
-      test: {
-        name: 'storybook',
-        browser: {
-          enabled: true,
-          headless: true,
-          provider: playwright({}),
-          instances: [{
-            browser: 'chromium'
-          }]
+    projects: [
+      // ユニットテスト用プロジェクト
+      {
+        extends: true,
+        test: {
+          name: 'unit',
+          environment: 'jsdom',
+          include: ['src/**/*.test.{ts,tsx}'],
+        },
+      },
+      // storybookプロジェクト
+      {
+        extends: true,
+        plugins: [
+          // The plugin will run tests for the stories defined in your Storybook config
+          // See options at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon#storybooktest
+          storybookTest({
+            configDir: path.join(dirname, '.storybook')
+          })],
+        test: {
+          name: 'storybook',
+          browser: {
+            enabled: true,
+            headless: true,
+            provider: playwright({}),
+            instances: [{
+              browser: 'chromium'
+            }]
+          }
         }
       }
-    }]
+    ]
   }
 });


### PR DESCRIPTION
## 概要

Zustandによるグローバル状態管理とTanStack Queryによるデータフェッチ管理を実装し、各コンポーネントを統合した天気予報ダッシュボードのメインページを構築しました。

## 対応内容

- [x] `entities/weather/model/weather-store.ts` の実装 (Zustand + localStorageによる永続化)
- [x] `entities/weather/model/use-weather-query.ts` の実装 (TanStack QueryによるAPI連携)
- [x] `pages/weather/ui/page.tsx` の実装と各Widgetの配置
- [x] 48時間（Hourly）と7日間（Daily）の動的な指標選択への対応
- [x] 各レイヤーのユニットテストおよびStorybookによるテストの実施

## 変更の背景・目的

各レイヤーで個別に開発を進めてきたコンポーネントやロジックを統合し、ユーザーが都市や指標を自由に切り替えて閲覧できるSPAとして完成させるため。

## 動作確認

- [x] 都市選択（東京、大阪など）が正しく機能し、データが再取得されること
- [x] 指標（気温、降水量など）の複数選択および解除がグラフに反映されること
- [x] 48時間と7日間の切り替えが正しく動作すること
- [x] 単位（°C/°F, m/s / km/h）の切り替えが正しく反映されること
- [x] リロード後も選択状態が維持されること（localStorage）
- [x] 全てのユニットテストがパスすること

## 関連Issue

close #6

## 備考

7日間表示における動的な指標選択についても対応済みです。